### PR TITLE
Fix button height to match input field

### DIFF
--- a/src/components/AddTaskForm.tsx
+++ b/src/components/AddTaskForm.tsx
@@ -42,7 +42,7 @@ export function AddTaskForm({ onAddTask }: AddTaskFormProps) {
         type="submit"
         disabled={!taskText.trim()}
         variant="craft"
-        size="default"
+        size="lg"
       >
         Add
       </Button>


### PR DESCRIPTION
## What Changed
- Updated AddTaskForm button size from `default` (36px) to `lg` (40px)

## Visual Impact
- Button and input field are now perfectly aligned

## Technical Details
- Modified `src/components/AddTaskForm.tsx`
- Changed button `size` prop from `"default"` to `"lg"`