### PR TITLE
style: increase add button size to lg

### DIFF
--- a/src/components/AddTaskForm.tsx
+++ b/src/components/AddTaskForm.tsx
@@ -42,7 +42,7 @@ export function AddTaskForm({ onAddTask }: AddTaskFormProps) {
         type="submit"
         disabled={!taskText.trim()}
         variant="craft"
-        size="default"
+        size="lg"
       >
         Add
       </Button>


### PR DESCRIPTION
Changed add button size to lg from default
<img width="1054" height="212" alt="Screenshot 2026-04-28 at 5 49 28 PM" src="https://github.com/user-attachments/assets/dcd92ca4-c661-43eb-8e8d-1891c3a34e1b" />
