### PR TITLE
style: increase add button size to lg

### DIFF
--- a/src/components/AddTaskForm.tsx
+++ b/src/components/AddTaskForm.tsx
@@ -42,7 +42,7 @@ export function AddTaskForm({ onAddTask }: AddTaskFormProps) {
         type="submit"
         disabled={!taskText.trim()}
         variant="craft"
-        size="default"
+        size="lg"
       >
         Add
       </Button>


### PR DESCRIPTION
changed add button size to lg from default 
<img width="1057" height="476" alt="Screenshot 2026-04-28 at 5 49 30 PM" src="https://github.com/user-attachments/assets/56f21304-bd25-41bb-a201-b58dcaec196b" />
