### PR TITLE
style: increase add button size to lg

### DIFF
--- a/src/components/AddTaskForm.tsx
+++ b/src/components/AddTaskForm.tsx
@@ -42,7 +42,7 @@ export function AddTaskForm({ onAddTask }: AddTaskFormProps) {
         type="submit"
         disabled={!taskText.trim()}
         variant="craft"
-        size="default"
+        size="lg"
       >
         Add
       </Button>


### PR DESCRIPTION
Changed add button size to lg from default 

<img width="1103" height="557" alt="Screenshot 2026-04-28 at 5 49 26 PM" src="https://github.com/user-attachments/assets/76e31c51-354c-42be-9f9a-d73da4bcffcb" />
