### PR TITLE
style: increase add button size to lg

### DIFF
--- a/src/components/AddTaskForm.tsx
+++ b/src/components/AddTaskForm.tsx
@@ -42,7 +42,7 @@ export function AddTaskForm({ onAddTask }: AddTaskFormProps) {
         type="submit"
         disabled={!taskText.trim()}
         variant="craft"
-        size="default"
+        size="lg"
       >
         Add
       </Button>


### PR DESCRIPTION
Changed add button size to Lg from default 

<img width="1143" height="612" alt="Screenshot 2026-04-28 at 2 49 30 PM" src="https://github.com/user-attachments/assets/aab8af28-ed62-44a7-87cf-56f59b11f8b1" />
