### PR TITLE
style: increase add button size to lg

### DIFF
--- a/src/components/AddTaskForm.tsx
+++ b/src/components/AddTaskForm.tsx
@@ -42,7 +42,7 @@ export function AddTaskForm({ onAddTask }: AddTaskFormProps) {
         type="submit"
         disabled={!taskText.trim()}
         variant="craft"
-        size="default"
+        size="lg"
       >
         Add
       </Button>


### PR DESCRIPTION
Changed add button size to lg from default
<img width="1126" height="658" alt="Screenshot 2026-04-28 at 2 49 50 PM" src="https://github.com/user-attachments/assets/9bcd4114-5a66-4775-a503-dab41d75c01e" />
